### PR TITLE
Fixed potential login token conflict issue

### DIFF
--- a/Server/User/userhelper.py
+++ b/Server/User/userhelper.py
@@ -15,8 +15,21 @@ def verifyPassword(password, dbHash):
 	return bcrypt.verify(password, dbHash)
 
 def generateLoginToken(user):
-	user.token = uuid.uuid4().hex
-	user.save()
+	tokenTaken = True
+	maxAttempts = 20
+	attempt = 0
+	while tokenTaken and attempt < maxAttempts:
+		token = uuid.uuid4().hex
+		conflictUser = Users.objects.filter(token=token).first()
+		if not conflictUser:
+			user.token = token
+			user.save()
+			tokenTaken = False
+
+		attempt += 1
+
+	if tokenTaken:
+		logging.error("Login Token Generation Failed: 20 Attempts to generate a random token resulted in user conflicts")
 
 	return user.token
 

--- a/Server/User/userhelper.py
+++ b/Server/User/userhelper.py
@@ -14,12 +14,18 @@ def encrypt(password):
 def verifyPassword(password, dbHash):
 	return bcrypt.verify(password, dbHash)
 
+"""
+Generates and saves a login token for a particular user.
+This function should validate the token hasn't been taken before assigning it to a user.
+"""
 def generateLoginToken(user):
 	tokenTaken = True
 	maxAttempts = 20
 	attempt = 0
 	while tokenTaken and attempt < maxAttempts:
 		token = uuid.uuid4().hex
+
+		# Check to see if a user already has the generated token and retry if their is a match
 		conflictUser = Users.objects.filter(token=token).first()
 		if not conflictUser:
 			user.token = token


### PR DESCRIPTION
It will try generating a unique token up to 20 times.  If after 20 times, the unique id can't be generated something weird is up.  I don't foresee conflicts for login tokens happening that often and 1 retry (if any) should be enough to create a unique token.