### PR TITLE
Fix for Travis failures caused by a new release of Django Channels

### DIFF
--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.10.2
 asgi-redis>=0.10.0
-channels==0.17.3
+channels>=0.12.0
 daphne>=0.11.1
 Psycopg2==2.6.2
 coverage>=4.2

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.10.2
 asgi-redis>=0.10.0
-channels>=0.12.0
+channels==0.17.3
 daphne>=0.11.1
 Psycopg2==2.6.2
 coverage>=4.2


### PR DESCRIPTION
Django Channels 1.0.0 was recently released and since our requirements.txt had >= for the channels dependency it picked it up thus causing all of our unit tests to fail.  For now, I am requiring a specific older version of channels but I will eventually try to have us move over to the newer version.