### PR TITLE
Matchmaking logic now operates within a transaction

### DIFF
--- a/Server/Game/tasks.py
+++ b/Server/Game/tasks.py
@@ -49,8 +49,8 @@ def processMatchmakingQueue():
         logger.debug("Processing matchmaking queue")
 
         with transaction.atomic():
-            # Get the matchmaking queue
-            queue = Game_Queue.objects.filter()
+            # Get and lock the matchmaking queue
+            queue = Game_Queue.objects.select_for_update()
 
             # Get the latest version to use for creating games
             version = Version.objects.latest('pk')

--- a/Server/Game/tasks.py
+++ b/Server/Game/tasks.py
@@ -10,6 +10,7 @@ from Static.log_uploader import upload_logs
 import logging
 from Server import config
 from celery.utils.log import get_task_logger
+from django.db import transaction
 
 logger = get_task_logger(__name__)
 fh = logging.FileHandler('./matchmaking.log', mode='a')
@@ -47,94 +48,98 @@ def processMatchmakingQueue():
     try:
         logger.debug("Processing matchmaking queue")
 
-        # Get the matchmaking queue
-        queue = Game_Queue.objects.filter()
+        with transaction.atomic():
+            # Get the matchmaking queue
+            queue = Game_Queue.objects.filter()
 
-        # Get the latest version to use for creating games
-        version = Version.objects.latest('pk')
+            # Get the latest version to use for creating games
+            version = Version.objects.latest('pk')
 
-        # If there aren't at least 2 players in the queue then exit
-        if len(queue) < 2:
-            logger.debug("Not enough people in the queue to match...Exiting")
-            return
+            # If there aren't at least 2 players in the queue then exit
+            if len(queue) < 2:
+                logger.debug("Not enough people in the queue to match...Exiting")
+                return
 
-        # Take the first player of the queue
-        first_player = queue[0]
+            # Take the first player of the queue
+            first_player = queue[0]
 
-        # Randomly choose a second player from the remaining players on the queue
-        index = random.randint(1, len(queue) - 1)
-        second_player = queue[index]
+            # Randomly choose a second player from the remaining players on the queue
+            index = random.randint(1, len(queue) - 1)
+            second_player = queue[index]
 
-        logger.info("Found a match: " + str(first_player.user.username) + " vs. " + str(second_player.user.username))
+            logger.info("Found a match: " + str(first_player.user.username) + " vs. " + str(second_player.user.username))
 
-        # Determine the number of times these 2 players have played against each other
-        count = 0
-        for first_player_game_user in Game_User.objects.filter(user=first_player.user).exclude(game=None):
-            game_played = first_player_game_user.game
+            # Determine the number of times these 2 players have played against each other
+            count = 0
+            for first_player_game_user in Game_User.objects.filter(user=first_player.user).exclude(game=None):
+                game_played = first_player_game_user.game
 
-            is_second_player_in_game = Game_User.objects.filter(user=second_player.user, game=game_played).first()
+                is_second_player_in_game = Game_User.objects.filter(user=second_player.user, game=game_played).first()
 
-            if is_second_player_in_game:
-                count += 1
+                if is_second_player_in_game:
+                    count += 1
 
-        logger.info("Users have played each other " + str(count) + " times.")
+            logger.info("Users have played each other " + str(count) + " times.")
 
-        # Randomly choose which player will start first
-        player_turn_index = random.randint(1, 2)
-        player_turn = None
-        if player_turn_index == 1:
-            logger.info(str(first_player.user.username) + " will take the first turn")
-            player_turn = first_player.user
-        elif player_turn_index == 2:
-            logger.info(str(second_player.user.username) + " will take the first turn")
-            player_turn = second_player.user
+            # Randomly choose which player will start first
+            player_turn_index = random.randint(1, 2)
+            player_turn = None
+            if player_turn_index == 1:
+                logger.info(str(first_player.user.username) + " will take the first turn")
+                player_turn = first_player.user
+            elif player_turn_index == 2:
+                logger.info(str(second_player.user.username) + " will take the first turn")
+                player_turn = second_player.user
 
-        maps = Map.objects.filter()
+            maps = Map.objects.filter()
 
-        # Randomly choose a map for the game
-        index = random.randint(0, maps.count() - 1)
-        game_map = maps.filter()[index]
+            # Randomly choose a map for the game
+            index = random.randint(0, maps.count() - 1)
+            game_map = maps.filter()[index]
 
-        logger.info("Map chosen for this game: " + str(game_map))
+            logger.info("Map chosen for this game: " + str(game_map))
 
-        # Create the game
-        game = Game(user_turn=player_turn, version=version, map_path=game_map)
-        game.save()
+            # Create the game
+            game = Game(user_turn=player_turn, version=version, map_path=game_map)
+            game.save()
 
-        logger.info("Created game id: " + str(game.id))
+            if 'UT-Fail' in os.environ:
+                raise Exception("Fail purposely")
 
-        game_users = Game_User.objects
+            logger.info("Created game id: " + str(game.id))
 
-        logger.debug("Updating game_user entries")
+            game_users = Game_User.objects
 
-        # Link the game to the first player's game entry
-        game_user1 = game_users.filter(user=first_player.user, game=None).first()
-        game_user1.game = game
-        game_user1.name = "vs. " + str(second_player.user.username) + " #" + str(count + 1)
-        game_user1.team = 1
-        game_user1.save()
+            logger.debug("Updating game_user entries")
 
-        # Link the game to the second player's game entry
-        game_user2 = game_users.filter(user=second_player.user, game=None).first()
-        game_user2.game = game
-        game_user2.name = "vs. " + str(first_player.user.username) + " #" + str(count + 1)
-        game_user2.team = 2
-        game_user2.save()
+            # Link the game to the first player's game entry
+            game_user1 = game_users.filter(user=first_player.user, game=None).first()
+            game_user1.game = game
+            game_user1.name = "vs. " + str(second_player.user.username) + " #" + str(count + 1)
+            game_user1.team = 1
+            game_user1.save()
 
-        logging.debug("Updating each player's unit entries")
+            # Link the game to the second player's game entry
+            game_user2 = game_users.filter(user=second_player.user, game=None).first()
+            game_user2.game = game
+            game_user2.name = "vs. " + str(first_player.user.username) + " #" + str(count + 1)
+            game_user2.team = 2
+            game_user2.save()
 
-        # Update each player's units
-        for unit in Unit.objects.filter(owner__in=[first_player.user, second_player.user], game=None):
-            unit.game = game
-            unit.save()
+            logging.debug("Updating each player's unit entries")
 
-        logger.debug("Deleting players from the queue")
+            # Update each player's units
+            for unit in Unit.objects.filter(owner__in=[first_player.user, second_player.user], game=None):
+                unit.game = game
+                unit.save()
 
-        # Delete the first player from the queue
-        first_player.delete()
+            logger.debug("Deleting players from the queue")
 
-        # Delete the second player from the queue
-        second_player.delete()
+            # Delete the first player from the queue
+            first_player.delete()
+
+            # Delete the second player from the queue
+            second_player.delete()
     except Exception, e:
         logger.error("Exception in the matchmaking logic")
         logger.exception(e)

--- a/Server/Game/tests.py
+++ b/Server/Game/tests.py
@@ -425,6 +425,21 @@ class TestMatchmaking(TestGame):
 		# Ensure that the Game Queue is now empty
 		self.assertTrue(Game_Queue.objects.count() == 0)
 
+	def test_mm_04_matchmaking_exception_rollback(self):
+		# Delete all game objects
+		Game.objects.filter().delete()
+
+		# Set unit test fail environment variable
+		os.environ['UT-Fail'] = "True"
+
+		# Should throw an exception after the game is created in db
+		processMatchmakingQueue()
+
+		del os.environ['UT-Fail']
+
+		# Validate that the game that was created gets rolled back
+		self.assertEqual(Game.objects.count(), 0)
+
 class TestPlaceUnits(TestGame):
 	"""
 	All tests within this class relate specifically to the command 'PU' (Place Units)


### PR DESCRIPTION
#152 

Should prevent race condition issues.  The queue should be locked when a worker executes and unlocks once the transaction completes.  If an exception occurs during the transaction all of the matchmaking changes should be rolled back so that the celery matchmaker can try again in subsequent runs.