### PR TITLE
Take Action, End Turn, account for units that have already acted

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 6f027641260ae4b6aa6cf4eba719e5c1
-folderAsset: yes
-timeCreated: 1492984168
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Communication/Server.cs
+++ b/Assets/Scripts/Communication/Server.cs
@@ -320,7 +320,7 @@ public static class Server {
 		return success;
 	}
 
-	//Called to end a player's turn (clearly lolol)
+	//Called to end a player's turn
 	public static bool EndTurn() {
 		var request = new Dictionary<string, object>();
 		request["Command"] = "ET";

--- a/Assets/Scripts/Communication/Server.cs
+++ b/Assets/Scripts/Communication/Server.cs
@@ -242,13 +242,10 @@ public static class Server {
 		request["Perks"] = perks;
 
 		Dictionary<string, object> response = SendCommand(request);
-
 		if (response == null){
 			return false;
 		}
-
 		bool success = (bool)response["Success"];
-
 		return success;
 	}
 
@@ -282,7 +279,9 @@ public static class Server {
 		request["Units"] = unitsDict;
 
 		Dictionary<string, object> response = SendCommand(request);
-
+		if (response == null){
+			return false;
+		}
 		bool success = (bool)response["Success"];
 		return success;
 	}
@@ -291,14 +290,47 @@ public static class Server {
 	public static bool CancelQueue() {
 		var request = new Dictionary<string, object>();
 		request["Command"] = "CS";
-		Dictionary<string, object> response = SendCommand(request);
 
+		Dictionary<string, object> response = SendCommand(request);
 		if (response == null){
 			return false;
 		}
-
 		bool success = (bool)response["Success"];
+		return success;
+	}
 
+	// Called to have a unit take an action on the game map (attacking/moving/etc.)
+	public static bool TakeAction(MatchUnit unit, string action, int X = -1, int Y = -1, int targetID = -1) {
+		var request = new Dictionary<string, object>();
+		request["Command"] = "TA";
+		request["Game"] = GameData.CurrentMatch.Name;
+		request["Action"] = action;
+		request["Unit"] = unit.ID;
+		request["X"] = (X == -1)? unit.X : X;
+		request["Y"] = (Y == -1)? unit.Y : Y;
+		if(targetID != -1) {
+			request["Target"] = targetID;
+		}
+
+		Dictionary<string, object> response = SendCommand(request);
+		if(response == null) {
+			return false;
+		}
+		bool success = (bool)response["Success"];
+		return success;
+	}
+
+	//Called to end a player's turn (clearly lolol)
+	public static bool EndTurn() {
+		var request = new Dictionary<string, object>();
+		request["Command"] = "ET";
+		request["Game"] = GameData.CurrentMatch.Name;
+
+		Dictionary<string, object> response = SendCommand(request);
+		if(response == null) {
+			return false;
+		}
+		bool success = (bool)response["Success"];
 		return success;
 	}
 

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -24,6 +24,11 @@ public class GameController : MonoBehaviour {
 	public static PlaceUnitsController PU;
 	public static bool PlacingUnits;
 	public static PUUnit UnitBeingPlaced;
+	public static Token IntendedMove;		// If the player has selected a token to move to but hasn't confirmed the move yet
+
+
+	// vars for development
+	private bool _endTurn;
 
 
 #region Setters and Getters
@@ -118,7 +123,7 @@ public class GameController : MonoBehaviour {
 	public void SelectUnit(Token token) {
 		Unit unit = token.CurrentUnit;
 		SelectedToken = token;
-		if(unit.MyTeam && !unit.TakenAction) {
+		if(unit.MyTeam && !unit.TakenAction && GameData.CurrentMatch.UserTurn) {
 			SetValidActions(token);
 		}else{
 			ShowUnitInfo(unit);
@@ -127,7 +132,7 @@ public class GameController : MonoBehaviour {
 
 	// Placeholder for what will contain code to show unit's info on UI
 	public void ShowUnitInfo(Unit unit) {
-
+		Debug.Log(((unit.MyTeam)? "Your " : "Opponent's ") + unit.Info.Name);
 	}
 
 	// Runs when a unit is unselected (i.e. user clicks other unit, or unit takes turn)
@@ -343,6 +348,25 @@ public class GameController : MonoBehaviour {
 		}
 		if(Input.GetKey("o")){
 			Camera.main.orthographicSize /= 0.95f;
+		}
+		if(Input.GetKeyDown("e")){
+			if(GameData.CurrentMatch.UserTurn) {
+				_endTurn = true;
+				Debug.Log("Press 'y' to confirm endturn, otherwise press 'n'");
+			}else {
+				Debug.Log("It's not your turn to end...");
+			}
+		}
+		if(_endTurn) {
+			if(Input.GetKeyDown("y")) {
+				if(Server.EndTurn()) {
+					Debug.Log("Turn ended");
+				}
+				_endTurn = false;
+			}else if(Input.GetKeyDown("n")) {
+				_endTurn = false;
+				Debug.Log("Endturn canceled");
+			}
 		}
 	}
 #endregion

--- a/Assets/Scripts/GameData/MatchData.cs
+++ b/Assets/Scripts/GameData/MatchData.cs
@@ -49,6 +49,7 @@ public class MatchData {
 			alliedUnit.PrevHP = 0;		// TODO - QGU doesn't send it
 			alliedUnit.X      = int.Parse(unit["X"].ToString());
 			alliedUnit.Y      = int.Parse(unit["Y"].ToString());
+			alliedUnit.Acted  = (bool)unit["Acted"];
 
 			AlliedUnits.Add(alliedUnit);
 		}
@@ -84,6 +85,7 @@ public class MatchData {
 			enemyUnit.PrevHP = 0;		// TODO - QGU doesn't send it
 			enemyUnit.X      = int.Parse(unit["X"].ToString());
 			enemyUnit.Y      = int.Parse(unit["Y"].ToString());
+			enemyUnit.Acted  = (bool)unit["Acted"];
 
 			EnemyUnits.Add(enemyUnit);
 		}
@@ -126,7 +128,8 @@ public class MatchData {
 			currAction.UnitNewHP     = int.Parse(actn["New_HP"].ToString());
 			currAction.UnitCrit      = (bool)actn["Crit"];
 			currAction.UnitMiss      = (bool)actn["Miss"];
-			currAction.TargetID      = int.Parse(actn["Target"].ToString());
+			// This is likely an inconsistency on the backend - but for now this fixes QGU errors
+			currAction.TargetID      = (actn["Target"] == null)? -1 : int.Parse(actn["Target"].ToString());
 			currAction.TargetOldHP   = int.Parse(actn["Tgt_Old_HP"].ToString());
 			currAction.TargetNewHP   = int.Parse(actn["Tgt_New_HP"].ToString());
 			currAction.TargetCounter = (bool)actn["Tgt_Counter"];
@@ -167,6 +170,7 @@ public struct MatchUnit {
 	public int    PrevHP;
 	public int    X;
 	public int    Y;
+	public bool   Acted;
 }
 
 public struct MatchLeader {

--- a/Assets/Scripts/Grid/Token.cs
+++ b/Assets/Scripts/Grid/Token.cs
@@ -71,26 +71,46 @@ public class Token : MonoBehaviour {
 				}
 			}else{ // Normal actions if not placing units
 				if(CurrentUnit != null) {
-					if(CurrentUnit.MyTeam && GameController.SelectedToken != null) {
-						if(this != GameController.SelectedToken) {
-							GameController.SelectedToken.CurrentUnit.UnselectUnit();
+					if(CanAttack) {
+
+					}else {
+						if(GameController.SelectedToken != null) {
+							if(this != GameController.SelectedToken) {
+								GameController.SelectedToken.CurrentUnit.UnselectUnit();
+							}
 						}
+						CurrentUnit.Clicked(this);
 					}
-					CurrentUnit.Clicked(this);
 				}else if(CanMove) {
-					MoveUnit(GameController.SelectedToken);
+					if(GameController.IntendedMove != this) {
+						SetIntendedMove();
+					}else {
+						ConfirmMove(GameController.SelectedToken);
+					}
+				}else {
+					if(GameController.SelectedToken != null) {
+						GameController.SelectedToken.CurrentUnit.UnselectUnit();
+					}
 				}
 			}
 		}
 	}
 
 	// Move unit from input prevToken to this token and unselect after
-	private void MoveUnit(Token prevToken) {
-		Unit unit = prevToken.CurrentUnit;
-		CurrentUnit = unit;
-		prevToken.CurrentUnit = null;
-		unit.transform.position = gameObject.transform.position;
-		unit.UnselectUnit();
+	private void SetIntendedMove() {
+		GameController.IntendedMove = this;
+		GameController.SelectedToken.CurrentUnit.transform.position = gameObject.transform.position;
+	}
+	// Move unit from input prevToken to this token and unselect after
+	private void ConfirmMove(Token prevToken) {
+		if(Server.TakeAction(prevToken.CurrentUnit.Info,"Wait", X, Y)) {
+			CurrentUnit = prevToken.CurrentUnit;
+			prevToken.CurrentUnit = null;
+			CurrentUnit.UpdateInfo(X: X, Y: Y);
+			CurrentUnit.TakenAction = true;
+			GameController.SelectedToken = null;
+			CurrentUnit.UnselectUnit();
+		}
 	}
 
 	// Token actions when unit is placed

--- a/Assets/Scripts/SpawnController.cs
+++ b/Assets/Scripts/SpawnController.cs
@@ -69,6 +69,7 @@ public class SpawnController : MonoBehaviour {
 			unit.X = x; unit.Y = y; unit.HP = GameData.GetUnit(unit.Name).GetStat("HP").Value;
 		}
 		ret.Info = unit;
+		ret.TakenAction = unit.Acted;
 		ret.MyTeam = myTeam;
 		GameController.Tokens[x][y].CurrentUnit = ret;
 		GameController.Units.Add(ret);

--- a/Assets/Scripts/Unit/Unit.cs
+++ b/Assets/Scripts/Unit/Unit.cs
@@ -69,15 +69,29 @@ public class Unit : MonoBehaviour {
 		}
 	}
 
+	// Updates matchunit info, defaulting each parameter to itself
+	// Pass in optional paramters via declaration: UpdateInfo(X: 5, Y: 7) to keep HP constant
+	public void UpdateInfo(int HP = -1, int X = -1, int Y = -1) {
+		MatchUnit tempUnit = new MatchUnit();
+		tempUnit = Info;
+		tempUnit.HP = (HP == -1)? tempUnit.HP : HP;
+		tempUnit.X = (X == -1)? tempUnit.X : X;
+		tempUnit.Y = (Y == -1)? tempUnit.Y : Y;
+		Info = tempUnit;
+	}
+
 	// Public function to deselect this unit
 	public void UnselectUnit() {
 		_selected = false;
+		GameController.IntendedMove = null;
+		if(GameController.SelectedToken != null) {
+			gameObject.transform.position = GameController.SelectedToken.gameObject.transform.position;
+		}
 		_gc.UnselectUnit();
 	}
 
 	// Resets unit at start of turn
 	public void Reset() {
-		_takenAction = false;
 		RemainingMoveRange = GameData.GetUnit(name).GetStat("Move").Value;
 	}
 


### PR DESCRIPTION
Take Action, End Turn, account for units that have already acted when opening game...

you'll have to login every time

to end turn, press “e”, a message pops up in the console saying press “y” to confirm, or “n” to cancel
so if you press “e”, then “y”, you’ll call end turn on the server. then you can login as the next person and do things