### PR TITLE
Server move bug

### DIFF
--- a/Server/Game/tests.py
+++ b/Server/Game/tests.py
@@ -787,10 +787,12 @@ class TestTakeAction(TestGame):
 		self.game.save()
 
 		# Commonly used units
+		# Note: By default 'attacker' will be ranged
 		self.melee_units = Unit_Stat.objects.filter(stat__name="Attack Range", value=1).values('unit')
 		self.heal_class = Class.objects.filter(name="Cleric", version=self.version).first()
 		self.attacker  = Unit.objects.filter(game=self.game, owner=self.user).exclude(
-			unit_class=self.heal_class).exclude(id__in=self.melee_units).first()
+			unit_class=self.heal_class).exclude(unit_class__in=self.melee_units).first()
+		self.assertEqual(self.attacker.unit_class.name,"Archer")
 		self.healer  = Unit.objects.filter(game=self.game, owner=self.user,
 			unit_class=self.heal_class).first()
 		self.enemy_tgt = Unit.objects.filter(game=self.game, owner=self.user2, unit_class__in=self.melee_units).exclude(
@@ -1432,8 +1434,13 @@ class TestTakeAction(TestGame):
 		self.helper_execute_failure(atk_dead_command, "You cannot attack dead units.")
 
 	def test_ta_12_crit_attack_success(self):
-		# Ensure the attacker always crits and always hits
+		# Ensure the attacker always crits and always hits - should kill the unit so it cannot counter
 		self.set_luck_and_agil(self.attacker.unit_class, 100, 15)
+
+		# Ensure attacking a unit that would be killed by a counter attack
+		flier_class = Class.objects.filter(name="Flier", version=self.version).first()
+		self.enemy_tgt.unit_class = flier_class
+		self.enemy_tgt.save()
 
 		# Move unit near target
 		self.atk_cmd = self.move_unit_near_target(self.atk_cmd, self.attacker, self.enemy_tgt)
@@ -1686,6 +1693,53 @@ class TestTakeAction(TestGame):
 			"Tgt_Crit":    True
 		}
 		self.helper_verify_crit_miss(result, unit, tgt, attack_data, action_history, crit_miss)
+
+	def test_ta_22_move_to_enter_not_leave(self):
+		# Set the map to the forest
+		map_obj = Map.objects.filter(version=self.version, name="Forest Pattern").first()
+		self.game.map_path = map_obj
+		self.game.save()
+
+		# Ensure the unit is an archer
+		archer_class = Class.objects.filter(name="Archer", version=self.version).first()
+		self.attacker.unit_class = archer_class
+
+		# Move the unit such that moving fully north will stop short of a forest
+		self.attacker.x = 15
+		self.attacker.y = 13
+		self.attacker.save()
+
+		# Move full distance north
+		self.no_tgt_cmd["X"] = self.attacker.x
+		self.no_tgt_cmd["Y"] = self.attacker.y - self.attacker_mv_rng
+
+		self.helper_execute_failure(self.no_tgt_cmd,
+			"Target location ({0},{1}) was out of reach for {2} at location ({3},{4}).".format(
+				self.no_tgt_cmd["X"], self.no_tgt_cmd["Y"],
+				self.attacker.unit_class.name,
+				self.attacker.x, self.attacker.y))
+
+	def test_ta_23_move_priority_queue_checker(self):
+		# Set the map to the forest
+		map_obj = Map.objects.filter(version=self.version, name="Forest Pattern").first()
+		self.game.map_path = map_obj
+		self.game.save()
+
+		# Ensure the unit is an archer
+		archer_class = Class.objects.filter(name="Armor", version=self.version).first()
+		self.attacker.unit_class = archer_class
+
+		# Move the unit such that moving fully north will stop short of a forest
+		self.attacker.x = 10
+		self.attacker.y = 13
+		self.attacker.save()
+
+		# Move full distance north
+		self.no_tgt_cmd["X"] = 9
+		self.no_tgt_cmd["Y"] = 11
+
+		self.helper_execute_move_success(self.no_tgt_cmd)
+
 
 class TestEndTurn(TestGame):
 	"""

--- a/Server/Game/unithelper.py
+++ b/Server/Game/unithelper.py
@@ -7,7 +7,7 @@
 .. moduleauthor:: Drew, Brennan, and Nick
 
 """
-import logging, math
+import logging, math, Queue
 from random import randint
 
 from Game.models import Action_History, Game, Game_User, Unit
@@ -468,13 +468,14 @@ def validateMove(unit, game, user, newX, newY):
 	# - Not occupied by ally
 	# - Current X,Y equals target X,Y
 	# Uses:
-	# valid_move_queue - List of tokens to check in queue, has the X, Y, and the remaining movement range
+	# valid_move_queue - Priority Queue of tokens to check in queue, has the X, Y, and the remaining movement range
 	# checked_tokens_dict - Dictionary of checked tokens, to ensure the same token is not checked twice
-	valid_move_queue = [{"X":unit.x, "Y":unit.y, "Remaining":move_range}]
+	valid_move_queue = Queue.PriorityQueue()
+	valid_move_queue.put((-move_range, {"X":unit.x, "Y":unit.y, "Remaining":move_range}))
 	checked_tokens_dict = {unit.x:{unit.y:True}}
-	while len(valid_move_queue) > 0:
+	while not valid_move_queue.empty():
 		# Get next list element and prepare for processing
-		token = valid_move_queue.pop(0)
+		token = valid_move_queue.get()[1]
 		x = token["X"]
 		y = token["Y"]
 		logging.debug("Checking location ({0},{1}).".format(x, y))
@@ -526,7 +527,7 @@ def validateMove(unit, game, user, newX, newY):
 
 				# If the unit can move to this location
 				if rem_mvmt >= 0:
-					valid_move_queue.append({"X":deltX,"Y":deltY,"Remaining":rem_mvmt})
+					valid_move_queue.put((-rem_mvmt,{"X":deltX,"Y":deltY,"Remaining":rem_mvmt}))
 
 	# If exited the while loop, target token was not found
 	error = "Target location ({0},{1}) was out of reach for {2} at location ({3},{4}).".format(newX, newY, class_name, unit.x, unit.y)

--- a/Server/Game/unithelper.py
+++ b/Server/Game/unithelper.py
@@ -469,6 +469,7 @@ def validateMove(unit, game, user, newX, newY):
 	# - Current X,Y equals target X,Y
 	# Uses:
 	# valid_move_queue - Priority Queue of tokens to check in queue, has the X, Y, and the remaining movement range
+	#					 Elements are inserted with negative movement remaining to provide reversed priority
 	# checked_tokens_dict - Dictionary of checked tokens, to ensure the same token is not checked twice
 	valid_move_queue = Queue.PriorityQueue()
 	valid_move_queue.put((-move_range, {"X":unit.x, "Y":unit.y, "Remaining":move_range}))


### PR DESCRIPTION
Added a priority queue to help determine valid movement locations on the server side.  This properly validates movement when the terrain types vary.

Additionally provided updates to tests such that there should not be an occasional test failure due to the incorrect unit getting selected during the unit tests.